### PR TITLE
Fix tight retry loop when qalc is not installed

### DIFF
--- a/CalculatorLauncher.qml
+++ b/CalculatorLauncher.qml
@@ -143,6 +143,16 @@ QtObject {
     }
 
     function getItemsQalc(trimmedQuery) {
+        if (QalcService.failed) {
+            return [{
+                name: "qalc is not available",
+                icon: "material:error_outline",
+                comment: "Install libqalculate or switch to the default engine in settings",
+                action: "none",
+                categories: ["Calculator"]
+            }];
+        }
+
         if (trimmedQuery !== lastSentQuery) {
             QalcService.lastResult = "";
             QalcService.calculate(trimmedQuery);

--- a/QalcService.qml
+++ b/QalcService.qml
@@ -8,8 +8,15 @@ Singleton {
     property bool active: false
     property string qalcCommand: "qalc -i -t -set \"decimal comma off\" -c 0"
     property string lastResult: ""
+    property bool failed: false
+    property int _failCount: 0
 
     signal resultReady(string result)
+
+    onActiveChanged: {
+        _failCount = 0
+        failed = false
+    }
 
     function splitCommand(cmd) {
         var args = []
@@ -60,9 +67,28 @@ Singleton {
 
         onRunningChanged: {
             if (!running && root.active) {
-                console.warn("Calculator: qalc process died, restarting...")
-                running = true
+                root._failCount++
+                if (root._failCount > 3) {
+                    console.warn("Calculator: qalc process failed repeatedly, giving up. Is qalc installed?")
+                    root.failed = true
+                    return
+                }
+                console.warn("Calculator: qalc process died, retrying (" + root._failCount + "/3)...")
+                retryTimer.interval = root._failCount * 1000
+                retryTimer.restart()
+            } else if (running) {
+                root._failCount = 0
+                root.failed = false
             }
+        }
+    }
+
+    Timer {
+        id: retryTimer
+        repeat: false
+        onTriggered: {
+            if (root.active && !qalcProc.running)
+                qalcProc.running = true
         }
     }
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "calculator",
     "name": "Calculator",
     "description": "A calculator plugin that evaluates mathematical expressions and copies results to clipboard",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "author": "Bruno Cesar Rocha <rochacbruno>",
     "icon": "calculate",
     "type": "launcher",


### PR DESCRIPTION
## Summary
- When qalc is not installed, the auto-restart handler in QalcService fired continuously in a tight loop, producing thousands of log messages per second in journalctl (even when the launcher was not in use)
- Retries are now capped at 3 attempts with increasing backoff (1s, 2s, 3s), then the service gives up and sets a `failed` flag
- The launcher shows a clear error message ("qalc is not available - install libqalculate or switch to the default engine") instead of an eternal "Calculating..." placeholder
- Re-enabling the qalc engine (e.g. toggling settings) resets the failure state so it tries again

Closes #8

## Test plan
- [ ] With qalc installed: verify calculations still work normally and process restarts on transient crashes
- [ ] With qalc uninstalled: verify retry stops after 3 attempts, error message shows in launcher, and journalctl is not flooded
- [ ] Toggle calc engine away from qalc and back: verify retry resets and attempts again