### PR TITLE
Support number separators in calculator expressions

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -29,6 +29,10 @@ function containsMathFunctions(expression) {
     return _getMathNamesRegex().test(expression);
 }
 
+function normalizeGroupedNumberSpaces(expression) {
+    return expression.replace(/(\d)\s+(?=\d)/g, '$1');
+}
+
 function _findMatchingParen(expr, openPos) {
     var depth = 1;
     var pos = openPos + 1;
@@ -245,7 +249,7 @@ function evaluate(expression) {
         };
     }
 
-    let cleaned = expression.trim();
+    let cleaned = normalizeGroupedNumberSpaces(expression.trim());
 
     if (cleaned.length === 0) {
         return {

--- a/calculator.js
+++ b/calculator.js
@@ -29,8 +29,8 @@ function containsMathFunctions(expression) {
     return _getMathNamesRegex().test(expression);
 }
 
-function normalizeGroupedNumberSpaces(expression) {
-    return expression.replace(/(\d)\s+(?=\d)/g, '$1');
+function normalizeGroupedNumberSeparators(expression) {
+    return expression.replace(/(\d)(?:\s+|_)(?=\d)/g, '$1');
 }
 
 function _findMatchingParen(expr, openPos) {
@@ -249,7 +249,7 @@ function evaluate(expression) {
         };
     }
 
-    let cleaned = normalizeGroupedNumberSpaces(expression.trim());
+    let cleaned = normalizeGroupedNumberSeparators(expression.trim());
 
     if (cleaned.length === 0) {
         return {

--- a/tests/test_functions.js
+++ b/tests/test_functions.js
@@ -123,6 +123,7 @@ const rejectTests = [
     { expr: "import('fs')", description: "Rejects import()" },
     { expr: "fetch('http://evil.com')", description: "Rejects fetch()" },
     { expr: "sin(1); alert(1)", description: "Rejects semicolon injection" },
+    { expr: "1 con structor", description: "Rejects spaced identifier fragments" },
 ];
 
 let passed = 0;

--- a/tests/test_functions.js
+++ b/tests/test_functions.js
@@ -124,6 +124,7 @@ const rejectTests = [
     { expr: "fetch('http://evil.com')", description: "Rejects fetch()" },
     { expr: "sin(1); alert(1)", description: "Rejects semicolon injection" },
     { expr: "1 con structor", description: "Rejects spaced identifier fragments" },
+    { expr: "1_foo", description: "Rejects underscore before identifier" },
 ];
 
 let passed = 0;

--- a/tests/test_precision.js
+++ b/tests/test_precision.js
@@ -14,6 +14,8 @@ const tests = [
     { expr: "999999999999999999 + 1", expected: "1000000000000000000", description: "Large integer addition (BigInt)" },
     { expr: "123456789012345678 * 2", expected: "246913578024691356", description: "Large integer multiplication (BigInt)" },
     { expr: "999999999999999999 - 999999999999999998", expected: "1", description: "Large integer subtraction" },
+    { expr: "30 000 + 3", expected: "30003", description: "Grouped number with spaces" },
+    { expr: "1 234 567 * 2", expected: "2469134", description: "Multiple grouped number spaces" },
 
     { expr: "2 + 2", expected: "4", description: "Simple addition" },
     { expr: "10 - 3", expected: "7", description: "Simple subtraction" },

--- a/tests/test_precision.js
+++ b/tests/test_precision.js
@@ -16,6 +16,8 @@ const tests = [
     { expr: "999999999999999999 - 999999999999999998", expected: "1", description: "Large integer subtraction" },
     { expr: "30 000 + 3", expected: "30003", description: "Grouped number with spaces" },
     { expr: "1 234 567 * 2", expected: "2469134", description: "Multiple grouped number spaces" },
+    { expr: "3_000 + 3", expected: "3003", description: "Grouped number with underscores" },
+    { expr: "1_234_567 * 2", expected: "2469134", description: "Multiple grouped number underscores" },
 
     { expr: "2 + 2", expected: "4", description: "Simple addition" },
     { expr: "10 - 3", expected: "7", description: "Simple subtraction" },


### PR DESCRIPTION
Really nice project, it was exactly what is was searching ty for making it!

When typing large numbers, I like to add separators like spaces (i also added underscores). This adds support for both using a small normalization step.

The normalization only removes spaces or underscores when they appear between digits, so validation remains strict and non-math input is still rejected.

Supported examples:

```
30 000 + 3
3_000 + 3
1 234 567 * 2
1_234_567 * 2
```

I also added tests for these cases.