### PR TITLE
Fix #14: Replace wl-copy with dms cl copy

### DIFF
--- a/CalculatorLauncher.qml
+++ b/CalculatorLauncher.qml
@@ -258,7 +258,7 @@ QtObject {
     }
 
     function copyToClipboard(text) {
-        Quickshell.execDetached(["sh", "-c", "echo -n '" + text + "' | wl-copy"]);
+        Quickshell.execDetached(["sh", "-c", "echo -n '" + text + "' | dms cl copy"]);
         showToast("Copied to clipboard: " + text);
     }
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "calculator",
     "name": "Calculator",
     "description": "A calculator plugin that evaluates mathematical expressions and copies results to clipboard",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "author": "Bruno Cesar Rocha <rochacbruno>",
     "icon": "calculate",
     "type": "launcher",
@@ -11,7 +11,7 @@
     "settings": "./CalculatorSettings.qml",
     "trigger": "=",
     "requires_dms": ">=1.4.0",
-    "requires": ["wl-copy"],
+    "requires": ["dms"],
     "permissions": [
         "settings_read",
         "settings_write",


### PR DESCRIPTION
## Summary
- Replace `wl-copy` with `dms cl copy` in the clipboard function, removing the hidden `wl-clipboard` dependency.
- Uses the built-in DMS clipboard CLI, matching the pattern used by other official plugins (e.g. DankLauncherKeys).

Closes #14